### PR TITLE
poloniex support

### DIFF
--- a/bitcoin_exchanges/old/poloniex.py
+++ b/bitcoin_exchanges/old/poloniex.py
@@ -1,0 +1,159 @@
+import urllib
+import urllib2
+import json
+import time
+import hmac,hashlib
+import requests
+from requests.exceptions import Timeout, ConnectionError
+from bitcoin_exchanges.exchange_util import ExchangeError
+
+REQ_TIMEOUT = 10  # seconds
+publicURL = 'https://poloniex.com/public?command='
+tradeURL = 'https://poloniex.com/tradingApi'
+
+def createTimeStamp(datestr, format="%Y-%m-%d %H:%M:%S"):
+    return time.mktime(time.strptime(datestr, format))
+
+class poloniex:
+    def __init__(self, APIKey=None, Secret=None):
+        self.APIKey = APIKey
+        self.Secret = Secret
+    
+    def post_process(self, before):
+        after = before
+
+        # Add timestamps if there isnt one but is a datetime
+        if('return' in after):
+            if(isinstance(after['return'], list)):
+                for x in xrange(0, len(after['return'])):
+                    if(isinstance(after['return'][x], dict)):
+                        if('datetime' in after['return'][x] and 'timestamp' not in after['return'][x]):
+                            after['return'][x]['timestamp'] = float(createTimeStamp(after['return'][x]['datetime']))
+                            
+        return after
+    
+    def api_query(self, command, req={}):
+
+        if(command == 'returnTicker' or command == "return24Volume"):
+            try:
+                ret = requests.get(publicURL + command, timeout=REQ_TIMEOUT)
+            except (ConnectionError, Timeout) as e:
+                raise ExchangeError('poloniex', 'Could not complete request %r for reason %s %s' % (command, type(e), str(e)))
+
+            return json.loads(ret.text)
+        
+        elif(command == "returnOrderBook" or command == "returnMarketTradeHistory"):
+            try:
+                ret = requests.get(publicURL + command + '&currencyPair=' + str(req['currencyPair']), timeout=REQ_TIMEOUT)
+            except (ConnectionError, Timeout) as e:
+                raise ExchangeError('poloniex', 'Could not complete request %r for reason %s %s' % (command, type(e), str(e)))
+
+            return json.loads(ret.text)
+
+        else:
+            req['command'] = command
+            req['nonce'] = int(time.time()*1000)
+            post_data = urllib.urlencode(req)
+            sign = hmac.new(self.Secret, post_data, hashlib.sha512).hexdigest()
+            headers = {
+                'Sign': sign,
+                'Key': self.APIKey
+            }
+            
+            try:
+                ret = requests.post(url=tradeURL, data=req,
+                                    headers=headers, timeout=REQ_TIMEOUT)
+            except (ConnectionError, Timeout) as e:
+                raise ExchangeError('poloniex', 'Could not complete request %r for reason %s %s' % (req, type(e), str(e)))
+
+            return json.loads(ret.text)
+
+    def returnTicker(self):
+        return self.api_query("returnTicker")
+
+    def return24Volume(self):
+        return self.api_query("return24Volume")
+
+    def returnOrderBook(self, currencyPair):
+        return self.api_query("returnOrderBook", {'currencyPair': currencyPair})
+
+    def returnMarketTradeHistory(self, currencyPair):
+        return self.api_query("returnMarketTradeHistory", {'currencyPair': currencyPair})
+
+
+    # Returns all of your balances.
+    # Outputs: 
+    # {"BTC":"0.59098578","LTC":"3.31117268", ... }
+    def returnBalances(self):
+        return self.api_query('returnBalances')
+    
+    def returnCompleteBalances(self):
+        return self.api_query('returnCompleteBalances')
+
+    
+    # Returns your open orders for a given market, specified by the "currencyPair" POST parameter, e.g. "BTC_XCP"
+    # Inputs:
+    # currencyPair  The currency pair e.g. "BTC_XCP"
+    # Outputs: 
+    # orderNumber   The order number
+    # type          sell or buy
+    # rate          Price the order is selling or buying at
+    # Amount        Quantity of order
+    # total         Total value of order (price * quantity)
+    def returnOpenOrders(self,currencyPair):
+        return self.api_query('returnOpenOrders', {'currencyPair': currencyPair})
+
+
+    # Returns your trade history for a given market, specified by the "currencyPair" POST parameter
+    # Inputs:
+    # currencyPair  The currency pair e.g. "BTC_XCP"
+    # Outputs: 
+    # date          Date in the form: "2014-02-19 03:44:59"
+    # rate          Price the order is selling or buying at
+    # amount        Quantity of order
+    # total         Total value of order (price * quantity)
+    # type          sell or buy
+    def returnTradeHistory(self,currencyPair):
+        return self.api_query('returnTradeHistory',{"currencyPair":currencyPair})
+
+    # Places a buy order in a given market. Required POST parameters are "currencyPair", "rate", and "amount". If successful, the method will return the order number.
+    # Inputs:
+    # currencyPair  The curreny pair
+    # rate          price the order is buying at
+    # amount        Amount of coins to buy
+    # Outputs: 
+    # orderNumber   The order number
+    def buy(self,currencyPair,rate,amount):
+        return self.api_query('buy',{"currencyPair":currencyPair,"rate":rate,"amount":amount})
+
+    # Places a sell order in a given market. Required POST parameters are "currencyPair", "rate", and "amount". If successful, the method will return the order number.
+    # Inputs:
+    # currencyPair  The curreny pair
+    # rate          price the order is selling at
+    # amount        Amount of coins to sell
+    # Outputs: 
+    # orderNumber   The order number
+    def sell(self,currencyPair,rate,amount):
+        return self.api_query('sell',{"currencyPair":currencyPair,"rate":rate,"amount":amount})
+
+    # Cancels an order you have placed in a given market. Required POST parameters are "currencyPair" and "orderNumber".
+    # Inputs:
+    # currencyPair  The curreny pair
+    # orderNumber   The order number to cancel
+    # Outputs: 
+    # succes        1 or 0
+    def cancel(self,currencyPair,orderNumber):
+        return self.api_query('cancelOrder',{"currencyPair":currencyPair,"orderNumber":orderNumber})
+
+    # Immediately places a withdrawal for a given currency, with no email confirmation. In order to use this method, the withdrawal privilege must be enabled for your API key. Required POST parameters are "currency", "amount", and "address". Sample output: {"response":"Withdrew 2398 NXT."} 
+    # Inputs:
+    # currency      The currency to withdraw
+    # amount        The amount of this coin to withdraw
+    # address       The withdrawal address
+    # Outputs: 
+    # response      Text containing message about the withdrawal
+    def withdraw(self, currency, amount, address):
+        return self.api_query('withdraw',{"currency":currency, "amount":amount, "address":address})
+
+    def returnDepositAddresses(self):
+        return self.api_query('returnDepositAddresses')

--- a/bitcoin_exchanges/poloniex.py
+++ b/bitcoin_exchanges/poloniex.py
@@ -1,0 +1,142 @@
+import time
+import json
+from moneyed.classes import Money, MultiMoney
+from exchange_util import exchange_config, ExchangeABC, ExchangeError, create_ticker, BLOCK_ORDERS, MyOrder
+
+from old import poloniex
+
+polo = poloniex.poloniex(APIKey=exchange_config['poloniex']['api_creds']['key'],
+                          Secret=exchange_config['poloniex']['api_creds']['secret'])
+
+REQ_TIMEOUT = poloniex.REQ_TIMEOUT
+
+currencyPair='USDT_BTC'
+
+class Poloniex(ExchangeABC):
+    name = 'poloniex'
+    fiatcurrency = 'USD'
+
+    def __init__(self):
+        super(Poloniex, self).__init__()
+
+    @classmethod
+    def get_ticker(cls, **kwargs):
+        rawticker = polo.returnTicker()
+        usdtick = rawticker['USDT_BTC']
+        return create_ticker(bid=usdtick['highestBid'], ask=usdtick['lowestAsk'],
+                             high=usdtick['high24hr'], low=usdtick['low24hr'],
+                             last=usdtick['last'], volume=usdtick['baseVolume'],
+                             timestamp=time.time(), currency='USD')
+
+    @classmethod
+    def get_order_book(cls, pair=None):
+        pair = currencyPair
+        return polo.returnOrderBook(currencyPair=pair)
+    
+    def get_balance(self, btype='total'):
+        data = polo.returnCompleteBalances()
+
+        # filter balances for btc and dash, report totals for both together
+        btc_bal = data['BTC']
+        usdt_bal = data['USDT']
+        available = MultiMoney(Money(btc_bal['available'], currency='BTC'), Money(usdt_bal['available'], currency='USD'))
+        onOrders = MultiMoney(Money(btc_bal['onOrders'], currency='BTC'), Money(usdt_bal['onOrders'], currency='USD'))
+        if btype == 'total':
+            return available + onOrders
+        elif btype == 'available':
+            return available
+        return available + onOrders, available
+            
+    def get_open_orders(self):        
+        try:
+            rawos = polo.returnOpenOrders(currencyPair)
+        except ValueError as e:
+            raise ExchangeError('poloniex', '%s %s while sending to poloniex get_open_orders' % (type(e), str(e)))
+        orders = []
+        for o in rawos:
+            side = 'ask' if o['type'] == 'sell' else 'bid'
+            orders.append(MyOrder(Money(o['rate'], self.fiatcurrency), Money(o['amount']), side,
+                                  self.name, str(o['orderNumber'])))
+        print orders
+        return orders
+    
+    def create_order(self, amount, price, otype):
+        rate=price
+        if BLOCK_ORDERS:
+            return "order blocked"
+        if otype == 'bid':
+            otype = 'buy'
+        elif otype == 'ask':
+            otype = 'sell'
+        else:
+            raise Exception('unknown side %r' % otype)
+
+        params = {
+            'rate' : price,
+            'amount' : amount,
+            'currencyPair' : currencyPair
+        }
+        
+        if otype == 'sell':
+            try:
+                order = polo.sell(amount=amount, rate=rate, currencyPair=currencyPair)
+            except ValueError as e:
+                raise ExchangeError('poloniex', '%s %s while sending to poloniex %r' % (type(e), str(e), params))
+        else:
+            try:
+                order = polo.buy(amount=amount, rate=rate, currencyPair=currencyPair)
+            except ValueError as e:
+                raise ExchangeError('poloniex', '%s %s while sending to poloniex %r' % (type(e), str(e), params))
+            
+        if 'orderNumber' in order and order['orderNumber']:
+            return str(order['orderNumber'])
+        raise ExchangeError('poloniex', 'unable to create order %r response was %r' % (params, order))
+
+    def cancel_order(self, oid):
+        params = {'currencyPair': currencyPair, 'orderNumber': oid}
+
+        try:
+            resp = polo.cancel(currencyPair, orderNumber=oid)
+        except ValueError as e:
+            raise ExchangeError('poloniex', '%s %s while sending to poloniex %r' % (type(e), str(e), params))
+        print resp
+        if resp and 'success' in resp and resp['success'] == 1:
+            return True
+        elif 'error' in resp and resp['error'] == 'Order could not be cancelled.':
+            return True
+        else:
+            return False
+        
+        #get all open orders, then cancel each
+    def cancel_orders(self, **kwargs):
+        try:
+            olist = self.get_open_orders()
+        except ExchangeError as ee:
+            if ee.error == "no orders":
+                return True
+            else:
+                raise ee
+        success = True
+        for o in olist:
+            if not self.cancel_order(o.order_id):
+                success = False
+        return success
+            
+    def get_deposit_address(self):
+        result = polo.returnDepositAddresses()
+        print result
+        return str(result['BTC'])
+    # TODO: returns addresses per coin
+
+    def get_transactions(self, limit=None):
+        params = {'currencyPair': currencyPair}
+        try:
+            return polo.returnTradeHistory(params)
+        except ValueError as e:
+            raise ExchangeError('poloniex', '%s %s while sending to poloniex get_transactions' % (type(e), str(e)))
+
+
+
+eclass = Poloniex
+exchange = Poloniex()
+

--- a/bitcoin_exchanges/poloniex.py
+++ b/bitcoin_exchanges/poloniex.py
@@ -57,7 +57,6 @@ class Poloniex(ExchangeABC):
             side = 'ask' if o['type'] == 'sell' else 'bid'
             orders.append(MyOrder(Money(o['rate'], self.fiatcurrency), Money(o['amount']), side,
                                   self.name, str(o['orderNumber'])))
-        print orders
         return orders
     
     def create_order(self, amount, price, otype):
@@ -99,7 +98,6 @@ class Poloniex(ExchangeABC):
             resp = polo.cancel(currencyPair, orderNumber=oid)
         except ValueError as e:
             raise ExchangeError('poloniex', '%s %s while sending to poloniex %r' % (type(e), str(e), params))
-        print resp
         if resp and 'success' in resp and resp['success'] == 1:
             return True
         elif 'error' in resp and resp['error'] == 'Order could not be cancelled.':
@@ -124,7 +122,6 @@ class Poloniex(ExchangeABC):
             
     def get_deposit_address(self):
         result = polo.returnDepositAddresses()
-        print result
         return str(result['BTC'])
     # TODO: returns addresses per coin
 

--- a/exchange_config.py
+++ b/exchange_config.py
@@ -53,7 +53,16 @@ exchange_config = {
         'best_ask': -1,  # confirmed
         'api_creds': {'partner': '', 'secret': ''},
         'address': ''  # a deposit address from your account
+    },
+    'poloniex': {
+        'live': True,
+        'best_bid': 0, 
+        'best_ask': -1, 
+        'api_creds': {'key': '',
+                      'secret': ''},
+        'address': ''  # a deposit address from your account
     }
+    
 }
 
 # replace with mongoDB collection for nonce tracking


### PR DESCRIPTION
Add support for poloniex using `USDT` as the fiat currency.

This implementation is passing all tests except for the request timeout test for `get_ticker`.

Unit test output:

```
$ python -m unittest -v clients
test_create_order (clients.TestAPI) ... ok
test_deposit_address (clients.TestAPI) ... ok
test_get_balance (clients.TestAPI) ... ok
test_get_open_orders (clients.TestAPI) ... ok
test_order_book (clients.TestAPI) ... ok
test_ticker (clients.TestAPI) ... FAIL
test_z_cancel_orders (clients.TestAPI) ... ok

=========================================================
FAIL: test_ticker (clients.TestAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "clients.py", line 30, in test_ticker
    self.assertRaises(ExchangeError, mod.eclass.get_ticker)
AssertionError: ExchangeError not raised

----------------------------------------------------------------------
Ran 7 tests in 11.762s

FAILED (failures=1)
```
